### PR TITLE
Use SQL Server LocalDB in architecture docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ MessagingApp is a cross-platform messaging system built entirely on the .NET pla
 - SignalR hubs for real-time presence and call signaling.
 - Media service storing encrypted blobs in Azure Blob Storage or equivalent.
 - Notification service integrating with FCM/APNs/Windows Push.
-- EF Core with PostgreSQL for relational data.
+- EF Core with SQL Server LocalDB for relational data.
 
 ## End-to-End Encryption
 - Utilizes the Signal Protocol for key exchange, session management, and message encryption.


### PR DESCRIPTION
## Summary
- document backend's EF Core now using SQL Server LocalDB instead of PostgreSQL

## Testing
- `dotnet test` (fails: command not found)
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68999ac3bfbc832490d1a6b0df574210