### PR TITLE
Add initial AuthService backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Build output
+bin/
+obj/
+
+# Visual Studio
+.vs/
+
+# Mac
+.DS_Store
+
+# User specific files
+*.user
+*.suo
+

--- a/MessagingApp.sln
+++ b/MessagingApp.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthService", "src/AuthService/AuthService.csproj", "{8A3B6D82-7376-4C4E-9E2B-0ED74E9AFDE5}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{8A3B6D82-7376-4C4E-9E2B-0ED74E9AFDE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{8A3B6D82-7376-4C4E-9E2B-0ED74E9AFDE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{8A3B6D82-7376-4C4E-9E2B-0ED74E9AFDE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{8A3B6D82-7376-4C4E-9E2B-0ED74E9AFDE5}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # MessagingApp
+
+This repository contains the codebase for the MessagingApp platform.
+
+## Backend Services
+
+The backend is composed of ASP.NET Core microservices. The initial `AuthService` provides a placeholder authentication API and can be found under `src/AuthService`.
+
+### Running the authentication service
+
+```
+cd src/AuthService
+# Requires the .NET 8 SDK
+ dotnet run
+```
+
+The service exposes a `POST /api/auth/login` endpoint which currently returns a dummy token.

--- a/src/AuthService/AuthService.csproj
+++ b/src/AuthService/AuthService.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/AuthService/Controllers/AuthController.cs
+++ b/src/AuthService/Controllers/AuthController.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace AuthService.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    [HttpPost("login")]
+    public IActionResult Login(LoginRequest request)
+    {
+        // TODO: Replace with real authentication logic
+        var token = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
+        return Ok(new { token });
+    }
+}
+
+public record LoginRequest(string Email, string Password);

--- a/src/AuthService/Program.cs
+++ b/src/AuthService/Program.cs
@@ -1,0 +1,9 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();


### PR DESCRIPTION
## Summary
- add .NET 8 AuthService project with dummy login endpoint
- document backend service and execution instructions
- track build artifacts via .gitignore

## Testing
- `dotnet build src/AuthService/AuthService.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68999d7914d08324b97e3aba44eb227d